### PR TITLE
VAST-style index calculation

### DIFF
--- a/src/spatq.cpp
+++ b/src/spatq.cpp
@@ -438,7 +438,9 @@ Type objective_function<Type>::operator() () {
     i0 = yr * N_yrs;
     i1 = (yr + 1) * N_yrs;
     for (int i = i0; i < i1; i++) {
-      Index(yr) += Ih(i) * exp(Ilog_n(i) + Ilog_w(i));
+      // Should prevent some numerical issues; cribbed from VAST index
+      // calculation.
+      Index(yr) += Ih(i) * exp(Ilog_n(i)) * exp(Ilog_w(i));
     }
   }
 


### PR DESCRIPTION
Use

```
h * exp(log(n)) * exp(log(w))
```

instead of

```
h * exp(log(n) + log(w))
```

[following VAST](https://github.com/James-Thorson-NOAA/VAST/blob/20b52822d011a3d7604c747b572920fd4e3fa727/inst/executables/VAST_v8_3_0.cpp#L1543).